### PR TITLE
Fixes segfaults when trying to write statusbar message when no statusbar exists

### DIFF
--- a/statusbar.c
+++ b/statusbar.c
@@ -366,6 +366,16 @@ void statusbar_message(const int dtmout, const char *format, ...) /* {{{ */
 		return;
 	}
 
+	/* check for statusbar */
+	if (statusbar == NULL)
+	{
+		if (cfg.loglvl >= LOG_DEBUG)
+			tnc_fprintf(stdout, LOG_INFO, message);
+		tnc_fprintf(logfp, LOG_DEBUG, "(stdscr==NULL) %s", message);
+        free(message);
+        return;
+	}
+
 	wipe_statusbar();
 
 	/* print message */


### PR DESCRIPTION
Fixes segfaults when trying to write statusbar message when no statusbar exists.

Uses the logging mechanism to record message in the same way as was previously done where no stdscr existed.
