### PR TITLE
Fix Makefile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@
 OUT 		= tasknc
 
 #variables
-CC      	= cc
+CC		?= cc
 CFLAGS 		= -Wall -g -Wextra -std=c99 -O2
-LDFLAGS 	= ${CFLAGS} -lncursesw
+LDFLAGS 	= ${CFLAGS}
+LDLIBS 		= -lncursesw
 VERSION 	= $(shell git describe)
 
 PREFIX 	   ?= /usr/local
@@ -42,7 +43,7 @@ uninstall:
 	$(CC) -c $(CFLAGS) $<
 
 $(OUT): $(OBJ)
-	$(CC) $(LDFLAGS) -o $@ $(OBJ)
+	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LDLIBS)
 
 tags: $(SRC)
 		ctags *.c *.h


### PR DESCRIPTION
Gcc4.6 and later evaluate linked libraries in different ordering,
so -l\* goes after the target object file.
CC=cc sets the compiler to cc _in every case_, even if the user
has defined an environment variable CC. =? fixes this
