### PR TITLE
src/keys.c: used KEY_EVENT only if it exists

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -119,7 +119,10 @@ struct keymap keymaps[] = {
     {KEY_UNDO, "undo"},
     {KEY_MOUSE, "mouse"},
     {KEY_RESIZE, "resize"},
+/* Optional deprecated ncurses feature. */
+#ifdef KEY_EVENT
     {KEY_EVENT, "event"},
+#endif
     {1, "C-a"},
     {2, "C-b"},
     {3, "C-c"},


### PR DESCRIPTION
On ncurses-6.3 the build fails as:

    src/keys.c:122:6: error: 'KEY_EVENT' undeclared here (not in a function); did you mean 'KEY_SLEFT'?
      122 |     {KEY_EVENT, "event"},
          |      ^~~~~~~~~
          |      KEY_SLEFT

ncurses-6.3 deprecated KEY_EVENT as:

     * mark wgetch-events feature as deprecated.
          + prevent  KEY_EVENT  from  appearing  in  curses.h  unless the
            configure option --enable-wgetch-events is used.